### PR TITLE
Cleanup old windows on focus change, add ability to ignore based on buffer/file type

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ require('specs').setup{
         winhl = "PMenu",
         fader = require('specs').linear_fader,
         resizer = require('specs').shrink_resizer
-    }
+    },
+    ignore_filetypes = {},
+    ignore_buftypes = {
+        nofile = true,
+    },
 }
 ```
 


### PR DESCRIPTION
There are two parts to this PR:

### 1. Circumvent `nvim` segmentation fault by avoiding operations on highlights in unfocused windows

- Not sure if there's a better way to check the state of the `luv` timer, e.g. instead of using `pcall(...)` and some `local closed` state, there might be an indication that the `timer.closing == true` or something.
- Not 100% sure what the criteria here is, but it seems to just be an issue with something in the `ui_compositor.c` within the `nvim` core when trying to operate on too many/old things at once. By opening a new tab and loading a a buffer in the now 2 tabs (mine are highlighted with treesitter, not sure if that matters), then flipping back and forth between them quickly you'll see that `nvim` just memory faults. This is the most consistent way I've been able to reproduce it, but I've had similar issues that aren't as niche as this that kill my entire session. If I need to be more clear on exactly how to reproduce this, let me know.

### 2. Add ability to not show specs based on buffer/file type

- Pretty straight forward, setup two tables that are passed to `setup(...)` that take a map-like table of file/buffer types to not show specs for.

---

Let me know what you think @edluffy.