### PR TITLE
Feature/inline opts

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ require('specs').setup{
     - Toggle Specs on/off
 
 Faders:
+- sinus_fader    `⌣/⌢\⌣/⌢\⌣/⌢\⌣/⌢`
 - linear_fader   `▁▂▂▃▃▄▄▅▅▆▆▇▇██`
 - exp_fader      `▁▁▁▁▂▂▂▃▃▃▄▄▅▆▇`
 
@@ -93,6 +94,9 @@ vim.api.nvim_set_keymap('n', '<C-b>', ':lua require("specs").show_specs()', { no
 -- You can even bind it to search jumping and more, example:
 vim.api.nvim_set_keymap('n', 'n', 'n:lua require("specs").show_specs()<CR>', { noremap = true, silent = true })
 vim.api.nvim_set_keymap('n', 'N', 'N:lua require("specs").show_specs()<CR>', { noremap = true, silent = true })
+
+-- Or maybe you do a lot of screen-casts and want to call attention to a specific line of code:
+vim.api.nvim_set_keymap('n', '<leader>v', ':lua require("specs").show_specs({width = 97, winhl = "Search", delay_ms = 610, inc_ms = 21})<CR>', { noremap = true, silent = true })
 ```
 
 ## Planned Features


### PR DESCRIPTION
This is a pretty simple (I think) change that allows us to specify options on the JIT invocation. This push updates the readme to include the new fade type I made. (Including really bad ascii art, curves... who knew?) and also documents how to call inline.

I made sure to preserve the existing (ne. User Default) options, prior to executing the inline override, rather than making a new method. Hope that's alright.