### PR TITLE
Fix: get jump distance in apparent cursor height

### DIFF
--- a/lua/specs/init.lua
+++ b/lua/specs/init.lua
@@ -5,9 +5,9 @@ local old_cur
 local au_toggle
 
 function M.on_cursor_moved()
-    local cur = vim.api.nvim_win_get_cursor(0)
+    local cur = vim.fn.winline() + vim.api.nvim_win_get_position(0)[1]
     if old_cur then
-        local jump = math.abs(cur[1]-old_cur[1])
+        local jump = math.abs(cur-old_cur)
         if jump >= opts.min_jump then
             M.show_specs()
         end


### PR DESCRIPTION
This PR will stop unexpected flashes when cursor moves over folded lines which contain more than `min_jump` lines.